### PR TITLE
Fix vitest config path

### DIFF
--- a/packages/@glow/utils/vite.config.ts
+++ b/packages/@glow/utils/vite.config.ts
@@ -1,4 +1,4 @@
 import { defineConfig, mergeConfig } from 'vite';
-import { vitestConfig } from '@n8n/vitest-config/frontend';
+import { vitestConfig } from '@glow/vitest-config/frontend';
 
 export default mergeConfig(defineConfig({}), vitestConfig);

--- a/packages/frontend/@glow/chat/vite.config.mts
+++ b/packages/frontend/@glow/chat/vite.config.mts
@@ -3,7 +3,7 @@ import { resolve } from 'path';
 import vue from '@vitejs/plugin-vue';
 import icons from 'unplugin-icons/vite';
 import dts from 'vite-plugin-dts';
-import { vitestConfig } from '@n8n/vitest-config/frontend';
+import { vitestConfig } from '@glow/vitest-config/frontend';
 
 const includeVue = process.env.INCLUDE_VUE === 'true';
 const srcPath = resolve(__dirname, 'src');

--- a/packages/frontend/@glow/composables/vite.config.ts
+++ b/packages/frontend/@glow/composables/vite.config.ts
@@ -1,4 +1,4 @@
 import { defineConfig, mergeConfig } from 'vite';
-import { vitestConfig } from '@n8n/vitest-config/frontend';
+import { vitestConfig } from '@glow/vitest-config/frontend';
 
 export default mergeConfig(defineConfig({}), vitestConfig);

--- a/packages/frontend/@glow/design-system/vite.config.mts
+++ b/packages/frontend/@glow/design-system/vite.config.mts
@@ -4,7 +4,7 @@ import { defineConfig, mergeConfig } from 'vite';
 import components from 'unplugin-vue-components/vite';
 import icons from 'unplugin-icons/vite';
 import iconsResolver from 'unplugin-icons/resolver';
-import { vitestConfig } from '@n8n/vitest-config/frontend';
+import { vitestConfig } from '@glow/vitest-config/frontend';
 
 const packagesDir = resolve(__dirname, '..', '..', '..');
 

--- a/packages/frontend/@glow/i18n/vite.config.ts
+++ b/packages/frontend/@glow/i18n/vite.config.ts
@@ -1,4 +1,4 @@
 import { defineConfig, mergeConfig } from 'vite';
-import { vitestConfig } from '@n8n/vitest-config/frontend';
+import { vitestConfig } from '@glow/vitest-config/frontend';
 
 export default mergeConfig(defineConfig({}), vitestConfig);

--- a/packages/frontend/@glow/rest-api-client/vite.config.ts
+++ b/packages/frontend/@glow/rest-api-client/vite.config.ts
@@ -1,4 +1,4 @@
 import { defineConfig, mergeConfig } from 'vite';
-import { createVitestConfig } from '@n8n/vitest-config/frontend';
+import { createVitestConfig } from '@glow/vitest-config/frontend';
 
 export default mergeConfig(defineConfig({}), createVitestConfig({ setupFiles: [] }));

--- a/packages/frontend/@glow/stores/vite.config.ts
+++ b/packages/frontend/@glow/stores/vite.config.ts
@@ -1,4 +1,4 @@
 import { defineConfig, mergeConfig } from 'vite';
-import { vitestConfig } from '@n8n/vitest-config/frontend';
+import { vitestConfig } from '@glow/vitest-config/frontend';
 
 export default mergeConfig(defineConfig({}), vitestConfig);

--- a/packages/frontend/editor-ui/vite.config.mts
+++ b/packages/frontend/editor-ui/vite.config.mts
@@ -4,7 +4,7 @@ import { defineConfig, mergeConfig } from 'vite';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 import svgLoader from 'vite-svg-loader';
 
-import { vitestConfig } from '@n8n/vitest-config/frontend';
+import { vitestConfig } from '@glow/vitest-config/frontend';
 import icons from 'unplugin-icons/vite';
 import iconsResolver from 'unplugin-icons/resolver';
 import components from 'unplugin-vue-components/vite';


### PR DESCRIPTION
## Summary
- switch imports from `@n8n/vitest-config` to `@glow/vitest-config`

## Testing
- `pnpm --filter @glow/chat lint` *(fails: Cannot find module '@n8n/eslint-config/shared')*
- `pnpm --filter @glow/chat build` *(fails: Rollup failed to resolve imports)*

------
https://chatgpt.com/codex/tasks/task_e_685116ebbee083229ca94b47c1e1b337