### PR TITLE
Add type declaration for tournament

### DIFF
--- a/packages/@glow/tournament/src/shims.d.ts
+++ b/packages/@glow/tournament/src/shims.d.ts
@@ -1,0 +1,1 @@
+declare module 'tournament';


### PR DESCRIPTION
## Summary
- add a `shims.d.ts` in `@glow/tournament` so TypeScript can build

## Testing
- `npx tsc -p packages/@glow/tournament/tsconfig.build.json`
- `pnpm --filter @glow/tournament build`

------
https://chatgpt.com/codex/tasks/task_e_68511bad7f808322b65beafa7b2eec5b

## Summary by Sourcery

Build:
- Add a type declaration shim for the 'tournament' module to enable TypeScript builds