### PR TITLE
Fix chat build aliases

### DIFF
--- a/packages/@glow/tournament/src/shims.d.ts
+++ b/packages/@glow/tournament/src/shims.d.ts
@@ -1,0 +1,1 @@
+declare module 'tournament';

--- a/packages/frontend/@glow/chat/tsconfig.json
+++ b/packages/frontend/@glow/chat/tsconfig.json
@@ -13,7 +13,8 @@
 		"resolveJsonModule": true,
 		"types": ["vitest/globals"],
 		"paths": {
-			"@glow/chat/*": ["./*"]
+			"@glow/chat/*": ["./*"],
+			"@n8n/chat/*": ["./*"]
 		},
 		"lib": ["esnext", "dom", "dom.iterable", "scripthost"],
 		// TODO: remove all options below this line

--- a/packages/frontend/@glow/chat/vite.config.mts
+++ b/packages/frontend/@glow/chat/vite.config.mts
@@ -21,8 +21,9 @@ export default mergeConfig(
 		],
 		resolve: {
 			alias: {
-				'@': srcPath,
-				'@n8n/chat': srcPath,
+                                '@': srcPath,
+                                '@n8n/chat': srcPath,
+                                '@glow/chat': srcPath,
 			},
 		},
 		define: {


### PR DESCRIPTION
## Summary
- map `@n8n/chat/*` and `@glow/chat/*` paths in the chat package
- expose `@glow/chat` alias to Vite so Rollup resolves imports

## Testing
- `npx tsc -p packages/@glow/tournament/tsconfig.build.json`
- `pnpm --filter @glow/tournament build`
- `pnpm --filter @glow/chat build`

------
https://chatgpt.com/codex/tasks/task_e_68511bad7f808322b65beafa7b2eec5b

## Summary by Sourcery

Fix chat package build by adding missing Vite and TypeScript path aliases for chat imports and introduce a shim for the tournament module

Build:
- Add '@glow/chat' alias in Vite config and map '@glow/chat/*' and '@n8n/chat/*' in TypeScript paths

Chores:
- Add shims.d.ts declaring the 'tournament' module for TypeScript